### PR TITLE
Feature/refactor error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,147 @@
-*.pyc
-*.pyo
+# Created by https://www.gitignore.io/api/intellij,python,virtualenv
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea
+
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# *.ipr
+
+### Python ###
+# Byte-compiled / optimized / DLL files
 __pycache__/
-junk/
-.idea/
-.coverage
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+### VirtualEnv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+# End of https://www.gitignore.io/api/intellij,python,virtualenv
+
+junk/

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ pip-selfcheck.json
 # End of https://www.gitignore.io/api/intellij,python,virtualenv
 
 junk/
+man/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-init:
-    pip3 install -r requirements.txt
+.PHONY: clean
 
-test:
-    nosetests -vv tests
+init:
+	pip3 install -r requirements.txt
+
+test: clean
+	nosetests -vv tests
+
+clean:
+	@find . -name *.pyc -delete; rm .coverage 2> /dev/null || true

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -1,1 +1,5 @@
 __all__ = ['client', 'user_auth', 'aws_auth']
+
+class CerberusClientException(Exception):
+    """Wrap third-party exceptions expected by the Cerberus client."""
+    pass

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='cerberus python client',
-    version='0.1.2',
+    version='0.2.0',
     install_requires=requirements,
     author='Ann Wallace',
     author_email='ann.wallace@nike.com',


### PR DESCRIPTION
This refactor allows the cerberus-python-client to be consumed by downstream projects without having to handle `sys.exit` calls. We're also now wrapping exceptions that are thrown so that downstream consumers don't have to worry about introducing Exceptions from other libraries if they aren't currently being used.