### PR TITLE
Fix #8: add Cerberus client version header to all requests

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -1,5 +1,8 @@
 __all__ = ['client', 'user_auth', 'aws_auth']
 
+CLIENT_VERSION = '0.4.0'
+
+
 class CerberusClientException(Exception):
     """Wrap third-party exceptions expected by the Cerberus client."""
     pass

--- a/cerberus/client.py
+++ b/cerberus/client.py
@@ -18,7 +18,7 @@ from requests.exceptions import RequestException
 
 from .aws_auth import AWSAuth
 from .user_auth import UserAuth
-from . import CerberusClientException
+from . import CerberusClientException, CLIENT_VERSION
 
 
 class CerberusClient(object):
@@ -39,6 +39,8 @@ class CerberusClient(object):
         self.set_token()
 
         self.HEADERS['X-Vault-Token'] = self.token
+        self.HEADERS['X-Cerberus-Client'] = 'CerberusPythonClient/' \
+                                                + CLIENT_VERSION
 
     def set_token(self):
         """Set the Vault token based on auth type"""

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, find_packages
+from cerberus import CLIENT_VERSION
 
 setup(
     name='cerberus-python-client',
-    version='0.3.1',
+    version=CLIENT_VERSION,
     install_requires=[
         'moto',
         'boto3',


### PR DESCRIPTION
@tlisonbee's issue popped up on my feed and I figured the fix was simple enough.

I moved the project version into the Cerberus module so that the version reported in setup.py and the header is kept in sync. It'll required updating the version in a new location but I think the benefit outweighs the cost :)

Cheers!