### PR TITLE
Removes moto dependency from the packaged install

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ['client', 'user_auth', 'aws_auth']
 
-CLIENT_VERSION = '0.5.0'
+CLIENT_VERSION = '0.6.0'
 
 
 class CerberusClientException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     name='cerberus-python-client',
     version=CLIENT_VERSION,
     install_requires=[
-        'moto',
         'boto3',
         'requests',
     ],


### PR DESCRIPTION
Hi,

The `moto` package is not needed when using the client, it seems to only be used during tests. It should not be included as a dependency of the python package. 

The moto package brings a significant amount of dependencies and in my case breaks some other applications due to conflict. 