### PR TITLE
Allowing parsing of IAM roles that include path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `Cerberus Python Client` will be documented in this file.
 
 ### Added
 
+###### 30-11-2017
+- Added support for paths in role ARN's - fix for [#13](https://github.com/Nike-Inc/cerberus-python-client/issues/13)
+
 ###### 27-02-2017
 - Added the ability for setting role ARN and region that differs from default for IAM role auth.
 

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ['client', 'user_auth', 'aws_auth']
 
-CLIENT_VERSION = '0.6.0'
+CLIENT_VERSION = '0.8.0'
 
 
 class CerberusClientException(Exception):

--- a/tests/test_aws_auth.py
+++ b/tests/test_aws_auth.py
@@ -43,10 +43,12 @@ class TestAWSAuth(unittest.TestCase):
     def _mock_decrypt(self):
         pass
 
+    @patch('requests.get')
     @patch('requests.post')
     @mock_kms
     @mock_sts
-    def test_get_token(self, mock_post):
+    def test_get_token(self, mock_post, mock_get):
+
         # Example Cerberus response.
         response_body = {
             "client_token": "9a8b5f0e-b41f-3fc7-1c94-3ed4a8057396",
@@ -60,11 +62,23 @@ class TestAWSAuth(unittest.TestCase):
             "renewable": True
         }
 
+        iam_info_response_body = {
+            "Code" : "Success",
+            "LastUpdated" : "2017-11-29T21:11:45Z",
+            "InstanceProfileArn" : "arn:aws:iam::123:instance-profile/rolepath/rolename",
+            "InstanceProfileId" : "AIPAJURSEGIIGKUJSHNXY"
+        }
+
+        iam_security_credentials_response_body = "rolename"
+
         client = boto3.client('kms', region_name='us-west-2')
         key_data = client.create_key()
         key_id = key_data['KeyMetadata']['KeyId']
 
         cipher_data = client.encrypt(KeyId=key_id, Plaintext=json.dumps(response_body).encode())
+
+        mock_get.side_effect = [self._mock_response(content=iam_security_credentials_response_body),
+                                self._mock_response(content=json.dumps(iam_info_response_body) )]
 
         mock_post.return_value = self._mock_response(
             content=json.dumps({'auth_data': base64.b64encode(cipher_data['CiphertextBlob']).decode()})
@@ -74,12 +88,12 @@ class TestAWSAuth(unittest.TestCase):
         auth_client = AWSAuth("https://cerberus.fake.com", region='us-east-1')
         token = auth_client.get_token()
         self.assertEqual(token, response_body['client_token'])
+        self.assertEqual(auth_client.role_arn, "arn:aws:iam::123:role/rolepath/rolename")
 
         # Now we'll make sure that it works w/ a supplied role ARN and region...
         test_principal_arn = "arn:aws:iam::123456789012:role/test_role"
 
-        auth_client = AWSAuth("https://cerberus.fake.com", test_principal_arn, "us-east-1"
-        )
+        auth_client = AWSAuth("https://cerberus.fake.com", test_principal_arn, "us-east-1")
         self.assertEqual(auth_client.role_arn, test_principal_arn)
 
         token = auth_client.get_token()

--- a/tests/test_aws_auth.py
+++ b/tests/test_aws_auth.py
@@ -65,7 +65,7 @@ class TestAWSAuth(unittest.TestCase):
         iam_info_response_body = {
             "Code" : "Success",
             "LastUpdated" : "2017-11-29T21:11:45Z",
-            "InstanceProfileArn" : "arn:aws:iam::123:instance-profile/rolepath/rolename",
+            "InstanceProfileArn" : "arn:aws:iam::123:instance-profile/rolepath/instanceprofilename",
             "InstanceProfileId" : "AIPAJURSEGIIGKUJSHNXY"
         }
 


### PR DESCRIPTION
Bugfix for https://github.com/Nike-Inc/cerberus-python-client/issues/13

* Allowing parsing of assumed IAM roles on EC2 instances that contain role path
* Tests