### PR TITLE
Removes printing of sensitive information

### DIFF
--- a/cerberus/client.py
+++ b/cerberus/client.py
@@ -512,7 +512,6 @@ class CerberusClient(object):
         """
         if not version:
             version = "CURRENT"
-        print(self.HEADERS)
         payload = {'versionId': str(version)}
         secret_resp = get_with_retry(str.join('', [self.cerberus_url, '/v1/secret/', secure_data_path]),
                                    params=payload, headers=self.HEADERS)


### PR DESCRIPTION
Sensitive header information (Cerberus tokens) is printed and ends up in logfiles. This is undesirable. 
Please contact Paolo.Radaelli@nike.com for more information or alignment. 