### PR TITLE
Removed print calls and fixed pep8 warnings in touched files.

### DIFF
--- a/cerberus/aws_auth.py
+++ b/cerberus/aws_auth.py
@@ -69,7 +69,7 @@ class AWSAuth(object):
         token = resp.json()['client_token']
         iam_principal_arn = resp.json()['metadata']['aws_iam_principal_arn']
         if self.verbose:
-            logger.debug('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn), file=sys.stderr)
+            print('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn), file=sys.stderr)
         logger.info('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn))
 
         return token

--- a/cerberus/aws_auth.py
+++ b/cerberus/aws_auth.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
+
 class AWSAuth(object):
     """Class to authenticate with an IAM Role"""
     HEADERS = {"Content-Type": "application/json", "X-Cerberus-Client": "CerberusPythonClient/" + CLIENT_VERSION}
@@ -48,7 +49,7 @@ class AWSAuth(object):
         readonly_credentials = creds.get_frozen_credentials()
 
         # hardcode get-caller-identity request
-        data = OrderedDict((('Action','GetCallerIdentity'), ('Version', '2011-06-15')))
+        data = OrderedDict((('Action', 'GetCallerIdentity'), ('Version', '2011-06-15')))
         url = 'https://sts.{}.amazonaws.com/'.format(self.region)
         request_object = awsrequest.AWSRequest(method='POST', url=url, data=data)
 
@@ -68,7 +69,7 @@ class AWSAuth(object):
         token = resp.json()['client_token']
         iam_principal_arn = resp.json()['metadata']['aws_iam_principal_arn']
         if self.verbose:
-            print('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn), file=sys.stderr)
+            logger.debug('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn), file=sys.stderr)
         logger.info('Successfully authenticated with Cerberus as {}'.format(iam_principal_arn))
 
         return token

--- a/cerberus/client.py
+++ b/cerberus/client.py
@@ -80,7 +80,7 @@ class CerberusClient(object):
         try:
             self.token = os.environ['CERBERUS_TOKEN']
             if self.verbose:
-                logger.debug("Overriding Cerberus token with environment variable.", file=sys.stderr)
+                print("Overriding Cerberus token with environment variable.", file=sys.stderr)
             logger.info("Overriding Cerberus token with environment variable.")
             return
         except Exception as e:

--- a/cerberus/user_auth.py
+++ b/cerberus/user_auth.py
@@ -13,10 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
 
-import requests
+import logging
+
 from . import CerberusClientException, CLIENT_VERSION
 
 from .util import throw_if_bad_response, get_with_retry, post_with_retry
+
+
+logger = logging.getLogger(__name__)
 
 
 class UserAuth(object):
@@ -28,12 +32,11 @@ class UserAuth(object):
         self.username = username
         self.password = password
 
-
     def get_auth(self):
         """Returns auth response which has client token unless MFA is required"""
         auth_resp = get_with_retry(self.cerberus_url + '/v2/auth/user',
-                                 auth=(self.username, self.password),
-                                 headers=self.HEADERS)
+                                   auth=(self.username, self.password),
+                                   headers=self.HEADERS)
 
         if auth_resp.status_code != 200:
             throw_if_bad_response(auth_resp)
@@ -60,17 +63,17 @@ class UserAuth(object):
             selection = "0"
             x = 1
         else:
-            print("Found the following MFA devices")
-            x=0
+            logger.info("Found the following MFA devices")
+            x = 0
             for device in devices:
-                print("{0}: {1}".format(x, device['name']))
+                logger.info("{0}: {1}".format(x, device['name']))
                 x = x + 1
 
             selection = input("Enter a selection: ")
         if selection.isdigit():
-            selection_num=int(str(selection))
+            selection_num = int(str(selection))
         else:
-            raise CerberusClientException( str.join('', ["Selection: '", selection,"' is not a number"]))
+            raise CerberusClientException(str.join('', ["Selection: '", selection, "' is not a number"]))
 
         if (selection_num >= x) or (selection_num < 0):
             raise CerberusClientException(str.join('', ["Selection: '", str(selection_num), "' is out of range"]))

--- a/cerberus/user_auth.py
+++ b/cerberus/user_auth.py
@@ -63,10 +63,10 @@ class UserAuth(object):
             selection = "0"
             x = 1
         else:
-            logger.info("Found the following MFA devices")
+            print("Found the following MFA devices")
             x = 0
             for device in devices:
-                logger.info("{0}: {1}".format(x, device['name']))
+                print("{0}: {1}".format(x, device['name']))
                 x = x + 1
 
             selection = input("Enter a selection: ")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 boto3
+botocore


### PR DESCRIPTION
Replaced all print statements with logger.debug or logger.info calls. If the print statement occurred in a self.verbose check then debug was used otherwise info was used.

Also fixed and pep8 warnings in the modified files including:
* missing or to much white space
* lines that were to long
* missing or to many blank lines
* two # noinspection PyMethodMyBeStatic comments
* exception to broad clause, by logging a debug of the exception rather than passing
* variable value may not be used
* finally added botocore to the requirements file for pep8 even though boto3 implies it